### PR TITLE
Convert behavior of ignoring keys while an input is focused to a setting

### DIFF
--- a/src/bootstrap-state.js
+++ b/src/bootstrap-state.js
@@ -40,7 +40,7 @@ KJ.bootstrapState = function bootstrapState(state = {}, callback) {
 
 function processOptions(options) {
   const defaultOptions = {
-    optionsVersion: 2,
+    optionsVersion: 3,
     activationShortcut: {
       key: ',',
       shiftKey: false,
@@ -57,6 +57,7 @@ function processOptions(options) {
     },
     autoTrigger: true,
     activateNewTab: true,
+    ignoreWhileInputFocussed: true,
   }
 
   let saveOptions = false
@@ -69,6 +70,11 @@ function processOptions(options) {
     saveOptions = true
     options.optionsVersion = 2
     options.activateNewTab = true
+  }
+  if (options.optionsVersion === 2) {
+    saveOptions = true
+    options.optionsVersion = 3
+    options.ignoreWhileInputFocussed = true
   }
   if (options.optionsVersion !== defaultOptions.optionsVersion) {
     saveOptions = true

--- a/src/content.js
+++ b/src/content.js
@@ -46,7 +46,13 @@ function setup() {
 }
 
 function keyboardEventCallback(event) {
-  if (!event.repeat && !canElementBeTypedIn(event.target)) {
+  if (
+    !event.repeat &&
+    !(
+      state.options.ignoreWhileInputFocussed &&
+      canElementBeTypedIn(event.target)
+    )
+  ) {
     if (event.type === 'keydown') {
       handleKeydown(event)
     } else if (event.type === 'keyup') {

--- a/src/options.html
+++ b/src/options.html
@@ -38,6 +38,13 @@
           Activate new tabs when opened
         </label>
       </div>
+
+      <div class="option">
+        <label>
+          <input type="checkbox" id="ignoreWhileInputFocussed" />
+          Ignore keys while input focussed
+        </label>
+      </div>
     </div>
 
     <script src="bootstrap-state.js"></script>

--- a/src/options.js
+++ b/src/options.js
@@ -18,6 +18,9 @@ function setup() {
   )
   const autoTriggerCheckbox = document.getElementById('autoTrigger')
   const activateNewTabCheckbox = document.getElementById('activateNewTab')
+  const ignoreWhileInputFocussedCheckbox = document.getElementById(
+    'ignoreWhileInputFocussed',
+  )
 
   activationShortcutInput.placeholder = getShortcutText(
     state.options.activationShortcut,
@@ -27,11 +30,17 @@ function setup() {
   )
   autoTriggerCheckbox.checked = state.options.autoTrigger
   activateNewTabCheckbox.checked = state.options.activateNewTab
+  ignoreWhileInputFocussedCheckbox.checked =
+    state.options.ignoreWhileInputFocussed
 
   bindShortcutInput('activationShortcut', activationShortcutInput)
   bindShortcutInput('newTabActivationShortcut', newTabActivationShortcutInput)
   autoTriggerCheckbox.addEventListener('change', setAutoTrigger)
   activateNewTabCheckbox.addEventListener('change', setActivateNewTab)
+  ignoreWhileInputFocussedCheckbox.addEventListener(
+    'change',
+    setIgnoreWhileInputFocussed,
+  )
 }
 
 function bindShortcutInput(optionsKey, inputElement) {
@@ -94,6 +103,10 @@ function setAutoTrigger(event) {
 
 function setActivateNewTab(event) {
   saveOptions({activateNewTab: event.target.checked})
+}
+
+function setIgnoreWhileInputFocussed(event) {
+  saveOptions({ignoreWhileInputFocussed: event.target.checked})
 }
 
 function saveOptions(options) {


### PR DESCRIPTION
This PR converts the behavior of ignoring keys while an input is focused to a setting.
This is useful for when you want to use a shortcut that does not necessarily overlap with typing in inputs so that it just always works. (In my case `Command + Enter`).