### PR TITLE
Add option for alphanumeric hints

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
     "ecmaVersion": 2019
   },
   "env": {
-    "node": true
+    "node": true,
+    "es6": true
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "prettier --write \"**/*.{md,json,js,css,html}\" && eslint --fix . && web-ext lint",
     "test": "npm run lint",
     "build": "web-ext build",
-    "start": "web-ext run",
+    "start": "web-ext run --verbose",
     "serve-tests": "node npm-scripts/start.js"
   },
   "devDependencies": {

--- a/src/bootstrap-state.js
+++ b/src/bootstrap-state.js
@@ -58,6 +58,8 @@ function processOptions(options) {
     autoTrigger: true,
     activateNewTab: true,
     ignoreWhileInputFocused: true,
+    useLettersForHints: false,
+    hintAlphabet: "JKLASDFUIOPWERTNMZXCV" // close to the home-row
   }
 
   let saveOptions = false

--- a/src/bootstrap-state.js
+++ b/src/bootstrap-state.js
@@ -40,7 +40,7 @@ KJ.bootstrapState = function bootstrapState(state = {}, callback) {
 
 function processOptions(options) {
   const defaultOptions = {
-    optionsVersion: 3,
+    optionsVersion: 4,
     activationShortcut: {
       key: ',',
       shiftKey: false,
@@ -59,7 +59,7 @@ function processOptions(options) {
     activateNewTab: true,
     ignoreWhileInputFocused: true,
     useLettersForHints: false,
-    hintAlphabet: 'JKLASDFGHUIOPWERTNMZXCV', // close to the home-row
+    hintAlphabet: 'JKLASDFGHUIOPWERT', // close to the home-row
   }
 
   let saveOptions = false
@@ -77,6 +77,12 @@ function processOptions(options) {
     saveOptions = true
     options.optionsVersion = 3
     options.ignoreWhileInputFocused = true
+  }
+  if (options.optionsVersion === 3) {
+    saveOptions = true
+    options.optionsVersion = 4
+    options.useLettersForHints = false
+    options.hintAlphabet = 'JKLASDFGHUIOPWERT'
   }
   if (options.optionsVersion !== defaultOptions.optionsVersion) {
     saveOptions = true

--- a/src/bootstrap-state.js
+++ b/src/bootstrap-state.js
@@ -59,7 +59,7 @@ function processOptions(options) {
     activateNewTab: true,
     ignoreWhileInputFocused: true,
     useLettersForHints: false,
-    hintAlphabet: "JKLASDFUIOPWERTNMZXCV" // close to the home-row
+    hintAlphabet: 'JKLASDFGHUIOPWERTNMZXCV', // close to the home-row
   }
 
   let saveOptions = false

--- a/src/content.js
+++ b/src/content.js
@@ -169,7 +169,6 @@ function handleActivationKey(event) {
     state.openInNewTab = isNewTabActivationShortcut
     activateHintMode()
   }
-
 }
 
 function handleEscapeKey(event) {
@@ -195,7 +194,7 @@ function handleQueryKey(event) {
   const newQuery = (state.query + event.key).toUpperCase()
 
   // if O(n) turns out to be to slow for this, we could manage ids using a search tree
-  // but I think that's overkill for now  
+  // but I think that's overkill for now
   const newMatch = state.matches.find((elem) => elem.id.startsWith(newQuery))
 
   if (newMatch) {
@@ -203,7 +202,7 @@ function handleQueryKey(event) {
     state.matchingHint = newMatch
 
     filterHints()
-      
+
     if (state.options.autoTrigger && state.matches.length <= 1) {
       triggerMatchingHint()
     }
@@ -344,7 +343,9 @@ function filterHints() {
     hint.hintEl.classList[method](classNames.match)
   }
 
-  state.matches = state.matches.filter((elem) => elem.id.startsWith(state.query))
+  state.matches = state.matches.filter((elem) =>
+    elem.id.startsWith(state.query),
+  )
 }
 
 function shouldElementBeFocused(el) {

--- a/src/content.js
+++ b/src/content.js
@@ -271,12 +271,7 @@ function activateHintMode() {
     // when using alphanumeric hints, we use a seeded random number generator
     // to generate random looking hints that don't change when scrolling
     // (only when toggling hint mode)
-    state.initialRngSeed = Math.floor(+Date.now() / 100000)
-    state.rngSeed = state.initialRngSeed
-
-    // shuffle target elements to avoid similarities in adjacent hints when
-    // using alphanumeric ids (see algorithm description in findHints())
-    state.targetEls = shuffle([...state.targetEls])
+    state.initialRngSeed = Math.floor(+Date.now() % 100000)
   }
 
   findHints()
@@ -397,13 +392,14 @@ function findHints() {
       // 1. They have to be unique.
       // 2. Letters that occur earlier in the alphabet string should occur more often
       //    (The user can then order the keys by how easily they are reachable).
-      // 3. Adjacent IDs should not look similar if possible.
+      // 3. Adjacent IDs should not start with the same letter (filter quickly)
       // 4. IDs should have at least two letters (mostly aesthetic, but saves time on typos)
       //
       // To satisfy the first 2 properties, we iterate through all words over the
-      // hint alphabet in (flipped) lexicographic order, but randomly skip words
+      // hint alphabet in lexicographic order, but randomly skip words
       // with probability depending on the position of their letters in the alphabet
-      // string. The third one we approximate by shuffling the array of targets.
+      // string. The third one we satisfy by having the least-significant letter at
+      // the beginning.
       hintId = getNextId(hintId, lookupTable)
     } else {
       hintId++

--- a/src/content.js
+++ b/src/content.js
@@ -419,19 +419,20 @@ function findHints() {
 
 function getNextId(id, lookupTable) {
   // implements the algorithm described above
-  
+
   const skipBias = 1.5
   const skipProb = 0.2
-  
-  let result = ""
+
+  let result = ''
   let carry = true
 
   // generally "increments" the string by one, where the least significant letter is at position 0
-  for (i = 0; i < id.length; i++) {    
+  for (let i = 0; i < id.length; i++) {
     let chr = id.charAt(i)
     let ord = lookupTable.get(chr)
+    let skip
 
-    // with a small probability we skip the current index completely to bring more 
+    // with a small probability we skip the current index completely to bring more
     // variety to the more significant positions of the ID. Don't make the ID longer
     // than it has to be, though.
     if (Math.random() < skipProb && i < id.length - 1) {
@@ -448,15 +449,16 @@ function getNextId(id, lookupTable) {
       }
 
       chr = lookupTable.get(ord)
-      
+
       // the higher in the alphabet the new letter is, the higher the chance that we skip it
-      skip = Math.floor(Math.random() * lookupTable.get("length") * skipBias) < ord
+      skip =
+        Math.floor(Math.random() * lookupTable.get('length') * skipBias) < ord
     } while (skip)
 
     result = result + chr
 
     if (!carry) {
-      return result + id.substr(i+1)
+      return result + id.substr(i + 1)
     }
   }
 
@@ -468,8 +470,8 @@ function getNextId(id, lookupTable) {
 }
 
 function shuffle(input) {
-  for (i = input.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i+1))
+  for (let i = input.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
     const temp = input[i]
     input[i] = input[j]
     input[j] = temp
@@ -481,15 +483,15 @@ function shuffle(input) {
 function generateAlphabetLookupTable(alphabet) {
   // Generates a lookup table that maps symbols to their position in the hint alphabet
   // and vice versa. Speeds up hint rendering.
-  const table = new Map();
+  const table = new Map()
   const noDuplicates = [...new Set(alphabet)]
   noDuplicates.forEach((elem, idx) => {
     table.set(elem, idx)
     table.set(idx, elem)
   })
 
-  table.set("length", noDuplicates.length)
-  
+  table.set('length', noDuplicates.length)
+
   return table
 }
 

--- a/src/content.js
+++ b/src/content.js
@@ -102,7 +102,7 @@ function handleKeydown(event) {
     stopKeyboardEvent(event)
   } else if (isActivationShortcut || isNewTabActivationShortcut) {
     handleActivationKey(event)
-  } else if (state.active && !eventHasModifierKey(event)) {
+  } else if (state.active && !eventHasNonShiftModifierKey(event)) {
     if (event.key === 'Escape') {
       handleEscapeKey(event)
     } else {
@@ -147,8 +147,8 @@ function stopKeyboardEvent(event) {
   event.stopImmediatePropagation()
 }
 
-function eventHasModifierKey(event) {
-  return !!(event.shiftKey || event.ctrlKey || event.altKey || event.metaKey)
+function eventHasNonShiftModifierKey(event) {
+  return !!(event.ctrlKey || event.altKey || event.metaKey)
 }
 
 function handleActivationKey(event) {

--- a/src/content.js
+++ b/src/content.js
@@ -106,7 +106,9 @@ function handleKeydown(event) {
     if (event.key === 'Escape') {
       handleEscapeKey(event)
     } else {
-      const allowedQueryCharacters = /[0-9A-Za-zÀ-ÖØ-öø-ÿ]/
+      const allowedQueryCharacters = state.options.useLettersForHints
+            ? /[0-9]/
+            : /[0-9A-Za-zÀ-ÖØ-öø-ÿ]/
 
       if (event.key.match(allowedQueryCharacters)) {
         handleQueryKey(event)

--- a/src/content.js
+++ b/src/content.js
@@ -106,9 +106,9 @@ function handleKeydown(event) {
     if (event.key === 'Escape') {
       handleEscapeKey(event)
     } else {
-      const allowedQueryCharacters = '1234567890'
+      const allowedQueryCharacters = /[0-9A-Za-zÀ-ÖØ-öø-ÿ]/
 
-      if (allowedQueryCharacters.includes(event.key)) {
+      if (event.key.match(allowedQueryCharacters)) {
         handleQueryKey(event)
       }
     }

--- a/src/options.css
+++ b/src/options.css
@@ -25,11 +25,13 @@
   margin-top: var(--KEYJUMP-option-margin);
 }
 
-.option-shortcut {
+.option-shortcut,
+.option-text {
   align-items: baseline;
 }
 
-.option-shortcut label {
+.option-shortcut label,
+.option-text label {
   flex: 1;
   -webkit-padding-end: var(--KEYJUMP-option-margin);
 }
@@ -60,4 +62,21 @@
 
 .option-shortcut input::placeholder {
   color: rgb(48, 57, 66);
+}
+
+.option-text input {
+  display: inline-block;
+  min-width: 12.5em;
+  min-height: var(--KEYJUMP-shortcut-input-height);
+  padding: 3px 0 1px 4px;
+  color: rgba(48, 57, 66, 0.6);
+  border: solid 1px #bfbfbf;
+  border-radius: 2px;
+  font-size: inherit;
+}
+
+.option-text input:focus {
+  background: white;
+  color: black;
+  border-color: black;
 }

--- a/src/options.html
+++ b/src/options.html
@@ -45,6 +45,20 @@
           Ignore shortcuts while text fields are focused
         </label>
       </div>
+
+      <div class="option">
+        <label>
+          <input type="checkbox" id="useLettersForHints" />
+          Use alphanumeric hints instead of numbers
+        </label>
+      </div>
+
+      <div class="option option-text">
+        <label for="hintAlphabetInput">
+          Alphabet used for alphanumeric hints
+        </label>
+        <input type="text" id="hintAlphabetInput" />
+      </div>
     </div>
 
     <script src="bootstrap-state.js"></script>

--- a/src/options.js
+++ b/src/options.js
@@ -23,11 +23,9 @@ function setup() {
     'ignoreWhileInputFocused',
   )
   const useLettersForHintsCheckbox =
-        document.getElementById('useLettersForHints')
+    document.getElementById('useLettersForHints')
 
-  const hintAlphabetInput = document.getElementById(
-    'hintAlphabetInput'
-  )
+  const hintAlphabetInput = document.getElementById('hintAlphabetInput')
 
   activationShortcutInput.placeholder = getShortcutText(
     state.options.activationShortcut,
@@ -134,7 +132,9 @@ function handleHintAlphabetInput(event) {
   const filteredInput = input.replace(/[^0-9A-Za-zÀ-ÖØ-öø-ÿ]/g, '')
 
   event.target.value = filteredInput
-  saveOptions({hintAlphabet: filteredInput})
+  saveOptions({
+    hintAlphabet: filteredInput,
+  })
 }
 
 function saveOptions(options) {

--- a/src/options.js
+++ b/src/options.js
@@ -128,7 +128,7 @@ function setUseLettersForHints(event) {
 
 function handleHintAlphabetInput(event) {
   // we want only alphanumeric characters
-  const input = event.target.value
+  const input = event.target.value.toUpperCase()
   const filteredInput = input.replace(/[^0-9A-Za-zÀ-ÖØ-öø-ÿ]/g, '')
 
   event.target.value = filteredInput

--- a/src/options.js
+++ b/src/options.js
@@ -16,10 +16,17 @@ function setup() {
   const newTabActivationShortcutInput = document.getElementById(
     'newTabActivationShortcutInput',
   )
+
   const autoTriggerCheckbox = document.getElementById('autoTrigger')
   const activateNewTabCheckbox = document.getElementById('activateNewTab')
   const ignoreWhileInputFocusedCheckbox = document.getElementById(
     'ignoreWhileInputFocused',
+  )
+  const useLettersForHintsCheckbox =
+        document.getElementById('useLettersForHints')
+
+  const hintAlphabetInput = document.getElementById(
+    'hintAlphabetInput'
   )
 
   activationShortcutInput.placeholder = getShortcutText(
@@ -28,15 +35,23 @@ function setup() {
   newTabActivationShortcutInput.placeholder = getShortcutText(
     state.options.newTabActivationShortcut,
   )
+
   autoTriggerCheckbox.checked = state.options.autoTrigger
   activateNewTabCheckbox.checked = state.options.activateNewTab
+  useLettersForHintsCheckbox.checked = state.options.useLettersForHints
   ignoreWhileInputFocusedCheckbox.checked =
     state.options.ignoreWhileInputFocused
 
+  hintAlphabetInput.value = state.options.hintAlphabet
+
   bindShortcutInput('activationShortcut', activationShortcutInput)
   bindShortcutInput('newTabActivationShortcut', newTabActivationShortcutInput)
+
+  hintAlphabetInput.addEventListener('change', setHintAlphabet)
+
   autoTriggerCheckbox.addEventListener('change', setAutoTrigger)
   activateNewTabCheckbox.addEventListener('change', setActivateNewTab)
+  useLettersForHintsCheckbox.addEventListener('change', setUseLettersForHints)
   ignoreWhileInputFocusedCheckbox.addEventListener(
     'change',
     setIgnoreWhileInputFocused,
@@ -107,6 +122,14 @@ function setActivateNewTab(event) {
 
 function setIgnoreWhileInputFocused(event) {
   saveOptions({ignoreWhileInputFocused: event.target.checked})
+}
+
+function setUseLettersForHints(event) {
+  saveOptions({useLettersForHints: event.target.checked})
+}
+
+function setHintAlphabet(event) {
+  saveOptions({hintAlphabet: event.target.value})
 }
 
 function saveOptions(options) {

--- a/src/options.js
+++ b/src/options.js
@@ -47,7 +47,7 @@ function setup() {
   bindShortcutInput('activationShortcut', activationShortcutInput)
   bindShortcutInput('newTabActivationShortcut', newTabActivationShortcutInput)
 
-  hintAlphabetInput.addEventListener('change', setHintAlphabet)
+  hintAlphabetInput.addEventListener('input', handleHintAlphabetInput)
 
   autoTriggerCheckbox.addEventListener('change', setAutoTrigger)
   activateNewTabCheckbox.addEventListener('change', setActivateNewTab)
@@ -128,8 +128,13 @@ function setUseLettersForHints(event) {
   saveOptions({useLettersForHints: event.target.checked})
 }
 
-function setHintAlphabet(event) {
-  saveOptions({hintAlphabet: event.target.value})
+function handleHintAlphabetInput(event) {
+  // we want only alphanumeric characters
+  const input = event.target.value
+  const filteredInput = input.replace(/[^0-9A-Za-zÀ-ÖØ-öø-ÿ]/g, '')
+
+  event.target.value = filteredInput
+  saveOptions({hintAlphabet: filteredInput})
 }
 
 function saveOptions(options) {


### PR DESCRIPTION
This PR adds the option to use alphanumeric hints instead of numbers. I personally prefer keeping my fingers close to the home row when navigating and this allows you to do that.

I had to change the matching algorithm a bit to work for non-numeric hints as well, I hope it's still performant enough. 

This also fixes a bug where hints would change their text when scrolling/zooming, which broke filtering.
![Options](https://user-images.githubusercontent.com/22426881/183286913-e4bd6e34-09c7-4109-bc22-9319d8ca9fe6.png)
![Example](https://user-images.githubusercontent.com/22426881/183286939-3587d604-ceb1-49ff-876b-696b23d2bbc2.png)
