### PR TITLE
findHints: Detect elements by accessibility role = button/link

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -369,8 +369,18 @@ function findHints() {
       'button:not([disabled])',
       '[contenteditable]:not([contenteditable=false]):not([disabled])',
       '[ng-click]:not([disabled])',
-      '[role=button]:not([disabled])',
+      '[onclick]',
+      // Detect by aria-roles, since modern apps might not use <button /> and <a href="..."/>
+      // (see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles)
       '[role=link]',
+      '[role=button]:not([disabled])',
+      '[role=radio]:not([disabled])',
+      '[role=checkbox]:not([disabled])',
+      '[role=textbox]:not([disabled])',
+      '[role=tab]:not([disabled])',
+      '[role=menuitem]:not([disabled])',
+      '[role=menuitemcheckbox]:not([disabled])',
+      '[role=menuitemradio]:not([disabled])',
       // GWT Anchor widget class
       // http://www.gwtproject.org/javadoc/latest/com/google/gwt/user/client/ui/Anchor.html
       '.gwt-Anchor',

--- a/src/content.js
+++ b/src/content.js
@@ -369,6 +369,8 @@ function findHints() {
       'button:not([disabled])',
       '[contenteditable]:not([contenteditable=false]):not([disabled])',
       '[ng-click]:not([disabled])',
+      '[role=button]:not([disabled])',
+      '[role=link]',
       // GWT Anchor widget class
       // http://www.gwtproject.org/javadoc/latest/com/google/gwt/user/client/ui/Anchor.html
       '.gwt-Anchor',


### PR DESCRIPTION
Sometimes modern apps don't use the actual `<button />` or `<input type="button / submit" />` elements, but other (e.g. `<div />`) tags with a click event. In those cases, the app might add the ARIA-role to help screen-readers to detect an element is clickable. [See here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles).

This PR makes the extension detect those elements using ARIA-role.
![image](https://github.com/KennethSundqvist/key-jump-browser-extension/assets/12451101/ee69a891-a6b3-4d67-b86a-333d873829b6)
